### PR TITLE
Add Traktor.Kontrol S3

### DIFF
--- a/cmdr/cmdr.TsiLib/Device.cs
+++ b/cmdr/cmdr.TsiLib/Device.cs
@@ -90,6 +90,7 @@ namespace cmdr.TsiLib
             if (
                 (deviceTypeStr == "Traktor.Kontrol S4 MK3") ||
                 (deviceTypeStr == "Traktor.Kontrol S2 MK3") ||
+                (deviceTypeStr == "Traktor.Kontrol S3") ||
                 (deviceTypeStr == "Traktor.Kontrol S8") ||
                 (deviceTypeStr == "Pioneer.DDJ-T1") ||
                 (deviceTypeStr == "Generic Keyboard") ||


### PR DESCRIPTION
Add Traktor Kontrol S3 to isGenericMidiDevice check so settings are parsed correctly. 
With this change I can export the default S3 settings from Traktor Pro 3.3 and modify them successfully. 